### PR TITLE
Fix compilation errors with Qt6

### DIFF
--- a/occt-qopenglwidget/OcctQtViewer.cpp
+++ b/occt-qopenglwidget/OcctQtViewer.cpp
@@ -490,9 +490,9 @@ void OcctQtViewer::mouseMoveEvent (QMouseEvent* theEvent)
 void OcctQtViewer::wheelEvent (QWheelEvent* theEvent)
 {
   QOpenGLWidget::wheelEvent (theEvent);
-  const Graphic3d_Vec2i aPos (theEvent->pos().x(), theEvent->pos().y());
+  const Graphic3d_Vec2i aPos (theEvent->position().x(), theEvent->position().y());
   if (!myView.IsNull()
-    && UpdateZoom (Aspect_ScrollDelta (aPos, theEvent->delta() / 8)))
+    && UpdateZoom (Aspect_ScrollDelta (aPos, theEvent->angleDelta().y() / 8)))
   {
     updateView();
   }

--- a/occt-qopenglwidget/main.cpp
+++ b/occt-qopenglwidget/main.cpp
@@ -23,7 +23,6 @@
 
 #include <Standard_WarningsDisable.hxx>
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QSurfaceFormat>
 
 #include <QAction>

--- a/occt-qopenglwidget/occt-qopenglwidget-sample.pro
+++ b/occt-qopenglwidget/occt-qopenglwidget-sample.pro
@@ -1,5 +1,6 @@
 TEMPLATE = app
 QT += widgets
+greaterThan(QT_MAJOR_VERSION, 5) { QT += openglwidgets }
 CONFIG += console
 
 # source code of the sample


### PR DESCRIPTION
Tested with:
    OpenCascade 7.6.0
    Qt 6.3.0
    Windows10 x64
    MSVC 2019
    GL 4.5.0 NVIDIA 456.71

With MSVC2019 many compilation warnings remain about redefinitions
of M_E, M_LOG2E, M_PI, M_SQRT2, ...